### PR TITLE
Ensure to load datalayer script once customer-data is loaded

### DIFF
--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -3,5 +3,8 @@ var config = {
         '*': {
             magepalGtmDatalayer: 'MagePal_GoogleTagManager/js/datalayer'
         }
+    },
+    shim: {
+        'MagePal_GoogleTagManager/js/datalayer': ['Magento_Customer/js/customer-data']
     }
 };


### PR DESCRIPTION
Hi,

I encountered a strange bug only on firefox.
The JS was loaded before customer-data is loaded.
It **sometimes** made the ajax add to cart being buggy.
Using shim to ensure the JS is loaded after customer-data JS fixed the issue