### PR TITLE
Fix: Invalid argument supplied for foreach()

### DIFF
--- a/Block/Data/Product.php
+++ b/Block/Data/Product.php
@@ -146,7 +146,7 @@ class Product extends AbstractProduct
     protected function getBreadCrumbPath()
     {
         $titleArray = [];
-        $breadCrumbs = $this->catalogHelper->getBreadcrumbPath();
+        $breadCrumbs = $this->catalogHelper->getBreadcrumbPath() ?? [];
 
         foreach ($breadCrumbs as $breadCrumb) {
             $titleArray[] = $breadCrumb['label'];


### PR DESCRIPTION
Fix: Warning: Invalid argument supplied for foreach() in /var/www/html/vendor/magepal/magento2-googletagmanager/Block/Data/Product.php on line 151

`1 exception(s):
Exception #0 (Exception): Warning: Invalid argument supplied for foreach() in /var/www/html/vendor/magepal/magento2-googletagmanager/Block/Data/Product.php on line 151

Exception #0 (Exception): Warning: Invalid argument supplied for foreach() in /var/www/html/vendor/magepal/magento2-googletagmanager/Block/Data/Product.php on line 151
<pre>#1 MagePal\GoogleTagManager\Block\Data\Product->getBreadCrumbPath() called at [vendor/magepal/magento2-googletagmanager/Block/Data/Product.php:75]
#2 MagePal\GoogleTagManager\Block\Data\Product->_prepareLayout() called at [vendor/magento/framework/View/Element/AbstractBlock.php:283]
#3 Magento\Framework\View\Element\AbstractBlock->setLayout() called at [generated/code/MagePal/GoogleTagManager/Block/Data/Product/Interceptor.php:505]
#4 MagePal\GoogleTagManager\Block\Data\Product\Interceptor->setLayout() called at [vendor/magento/framework/View/Layout/Generator/Block.php:149]
#5 Magento\Framework\View\Layout\Generator\Block->process() called at [vendor/magento/framework/View/Layout/GeneratorPool.php:81]
#6 Magento\Framework\View\Layout\GeneratorPool->process() called at [vendor/magento/framework/View/Layout.php:343]
#7 Magento\Framework\View\Layout->generateElements() called at [generated/code/Magento/Framework/View/Layout/Interceptor.php:89]
#8 Magento\Framework\View\Layout\Interceptor->generateElements() called at [vendor/magento/framework/View/Layout/Builder.php:129]
#9 Magento\Framework\View\Layout\Builder->generateLayoutBlocks() called at [vendor/magento/framework/View/Page/Builder.php:55]
#10 Magento\Framework\View\Page\Builder->generateLayoutBlocks() called at [vendor/magento/framework/View/Layout/Builder.php:65]
#11 Magento\Framework\View\Layout\Builder->build() called at [vendor/magento/framework/View/Layout.php:253]
#12 Magento\Framework\View\Layout->build() called at [vendor/magento/framework/View/Layout.php:875]
#13 Magento\Framework\View\Layout->getBlock() called at [generated/code/Magento/Framework/View/Layout/Interceptor.php:414]
#14 Magento\Framework\View\Layout\Interceptor->getBlock() called at [vendor/magento/module-cms/Helper/Page.php:171]
#15 Magento\Cms\Helper\Page->prepareResultPage() called at [vendor/magento/module-cms/Controller/Noroute/Index.php:47]
#16 Magento\Cms\Controller\Noroute\Index->execute() called at [vendor/magento/framework/Interception/Interceptor.php:58]
#17 Magento\Cms\Controller\Noroute\Index\Interceptor->___callParent() called at [vendor/magento/framework/Interception/Interceptor.php:138]
#18 Magento\Cms\Controller\Noroute\Index\Interceptor->Magento\Framework\Interception\{closure}() called at [app/code/Onilab/SEOUrls/Plugin/Noroute.php:73]`