### PR TITLE
Fix invalid JSON at widget initialization

### DIFF
--- a/view/frontend/templates/js.phtml
+++ b/view/frontend/templates/js.phtml
@@ -49,7 +49,7 @@ $containerCode = $block->getEmbeddedCode();
     {
         "*": {
             "magepalGtmDatalayer": {
-                "dataLayer": "<?= /* @noEscape */ $block->getDataLayerName() ?>",
+                "dataLayer": "<?= /* @noEscape */ $block->getDataLayerName() ?>"
             }
         }
     }


### PR DESCRIPTION
Since `2.6.1` json initializing `magepalGtmDatalayer` is invalid. This breaks scripts execusion, it's IMO critical:
`Uncaught SyntaxError: Unexpected token } in JSON at position 113
    at JSON.parse (<anonymous>)
    at getNodeData (scripts.js:87)
    at Array.map (<anonymous>)
    at scripts.js:117
    at apply (main.js:77)`