### PR TITLE
#69: Fix for incorrect price rendering for configurable products

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -259,30 +259,11 @@ class Data extends AbstractHelper
     }
 
     /**
-     * @param $product
+     * @param ProductInterface $product
      * @return float
      */
-    public function getProductPrice($product)
+    public function getProductPrice(ProductInterface $product): float
     {
-        $price = 0;
-
-        /** @var $product ProductInterface */
-        if ($product) {
-            $price = $product
-                ->getPriceInfo()
-                ->getPrice(FinalPrice::PRICE_CODE)
-                ->getAmount()
-                ->getBaseAmount() ?: 0;
-        }
-
-        if (!$price) {
-            if ($product->getTypeId() == Type::TYPE_SIMPLE) {
-                $price = $product->getPrice();
-            } else {
-                $price = $product->getFinalPrice();
-            }
-        }
-
-        return $this->formatPrice($price);
+        return $this->formatPrice($product->getFinalPrice());
     }
 }


### PR DESCRIPTION
Fixed price value, I would think, it always should be the final price, product type shouldn't matter. Final price incorporates tax/discount/special price and matches the displayed value on the product page.

In the current logic $price is always set, so the logic of simple/configurable is never called.
Thought about removing the `getProductPrice` method, but this could be an issue for people using this method in custom extensions.

**Explanation**:

```
$price = $product
                ->getPriceInfo()
                ->getPrice(FinalPrice::PRICE_CODE)
                ->getAmount()
```

Returns an AmountInterface object.

```
->getBaseAmount()
```

getBaseAmount() fetches the amount without tax calculations, for the the final price amount it seems you should call:

```
->getValue()
```

Which is equal to getFinalPrice(), so don't see much value for all the logic and just call ->getFinalPrice() on the product, and let the product decide what the correct route is for fetching the correct amount.

Tested on Magento 2.4.3 and 2.3.5-p1 with 2.7.0. 
- Checked configurable product
- Checked simple product
- Checked simple product with discount (catalog rule)