### PR TITLE
Add missing img-src policy for www.googletagmanager.com

### DIFF
--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -28,6 +28,7 @@
                 <value id="custom-csp-googleapis-img-ssl" type="host">https://www.googleadservices.com/</value>
                 <value id="custom-csp-googleapis-img-ga-ssl" type="host">https://www.google-analytics.com/</value>
                 <value id="custom-csp-google-img-ga-ssl" type="host">https://www.google.com/</value>
+                <value id="custom-csp-googletagmanager-img" type="host">www.googletagmanager.com</value>
             </values>
         </policy>
         <policy id="connect-src">


### PR DESCRIPTION
According to the [CSP documentation](https://developers.google.com/tag-platform/tag-manager/web/csp), the following directives are needed for the www.googletagmanager.com domain (when nonces or hashes are not used):

    script-src: 'unsafe-inline' https://www.googletagmanager.com
    img-src: www.googletagmanager.com

This PR adds the missing `img-src` policy.