### PR TITLE
Remove http:// domains from csp_whitelist.xml

### DIFF
--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -3,8 +3,7 @@
     <policies>
         <policy id="script-src">
             <values>
-                <value id="mp-csp-googleapis-js" type="host">http://www.googletagmanager.com/</value>
-                <value id="mp-csp-googleapis-js-ssl" type="host">https://www.googletagmanager.com/</value>
+                <value id="mp-csp-googleapis-js" type="host">https://www.googletagmanager.com/</value>
             </values>
         </policy>
         <policy id="frame-src">
@@ -15,28 +14,22 @@
         </policy>
         <policy id="media-src">
             <values>
-                <value id="custom-csp-googleapis-media" type="host">http://www.googleadservices.com/</value>
-                <value id="custom-csp-googleapis-media-ga" type="host">http://www.google-analytics.com/</value>
-                <value id="custom-csp-googleapis-media-ssl" type="host">https://www.googleadservices.com/</value>
-                <value id="custom-csp-googleapis-media-ga-ssl" type="host">https://www.google-analytics.com/</value>
+                <value id="custom-csp-googleapis-media" type="host">https://www.googleadservices.com/</value>
+                <value id="custom-csp-googleapis-media-ga" type="host">https://www.google-analytics.com/</value>
             </values>
         </policy>
         <policy id="img-src">
             <values>
-                <value id="custom-csp-googleapis-media" type="host">http://www.googleadservices.com/</value>
-                <value id="custom-csp-googleapis-media-ga" type="host">http://www.google-analytics.com/</value>
-                <value id="custom-csp-googleapis-img-ssl" type="host">https://www.googleadservices.com/</value>
-                <value id="custom-csp-googleapis-img-ga-ssl" type="host">https://www.google-analytics.com/</value>
+                <value id="custom-csp-googleapis-img" type="host">https://www.googleadservices.com/</value>
+                <value id="custom-csp-googleapis-img-ga" type="host">https://www.google-analytics.com/</value>
                 <value id="custom-csp-google-img-ga-ssl" type="host">https://www.google.com/</value>
                 <value id="custom-csp-googletagmanager-img" type="host">www.googletagmanager.com</value>
             </values>
         </policy>
         <policy id="connect-src">
             <values>
-                <value id="custom-csp-googleapis-cs" type="host">http://stats.g.doubleclick.net/</value>
-                <value id="custom-csp-googleapis-cs-ssl" type="host">https://stats.g.doubleclick.net/</value>
-                <value id="custom-csp-googleapis-cs-ga" type="host">http://www.google-analytics.com/</value>
-                <value id="custom-csp-googleapis-cs-ga-ssl" type="host">https://www.google-analytics.com/</value>
+                <value id="custom-csp-googleapis-cs" type="host">https://stats.g.doubleclick.net/</value>
+                <value id="custom-csp-googleapis-cs-ga" type="host">https://www.google-analytics.com/</value>
             </values>
         </policy>
     </policies>


### PR DESCRIPTION
Google itself recommends allowing only https:// urls for CSP policies, as can be seen by running their [CSP Evaluator](https://csp-evaluator.withgoogle.com/) tool against a store with this module installed:
<img width="1956" height="1095" alt="image" src="https://github.com/user-attachments/assets/b0070a4b-0b1d-4558-8b25-d65a1ba0f6c1" />

As such, this PR removes the http:// entries (which also helps to slightly reduce the store's total headers size).